### PR TITLE
Add support for verb: ListMetadataFormats

### DIFF
--- a/src/Controllers/OaiController.php
+++ b/src/Controllers/OaiController.php
@@ -147,7 +147,12 @@ class OaiController extends Controller
         $xmlDocument = ListMetadataFormatsDocument::create();
         $xmlDocument->setResponseDate();
         $xmlDocument->setRequestUrl($requestUrl);
-        $xmlDocument->setRequestSpec('oai_dc');
+
+        foreach (array_keys($this->config()->get('supported_formats')) as $metadataPrefix) {
+            $formatter = $this->getOaiRecordFormatter($metadataPrefix);
+
+            $xmlDocument->addSupportedFormatter($formatter);
+        }
 
         $this->getResponse()->setBody($xmlDocument->getDocumentBody());
 

--- a/src/Documents/ListMetadataFormatsDocument.php
+++ b/src/Documents/ListMetadataFormatsDocument.php
@@ -2,6 +2,8 @@
 
 namespace Terraformers\OpenArchive\Documents;
 
+use Terraformers\OpenArchive\Formatters\OaiRecordFormatter;
+
 class ListMetadataFormatsDocument extends OaiDocument
 {
 
@@ -10,6 +12,30 @@ class ListMetadataFormatsDocument extends OaiDocument
         parent::__construct();
 
         $this->setRequestVerb(OaiDocument::VERB_LIST_METADATA_FORMATS);
+    }
+
+    public function addSupportedFormatter(OaiRecordFormatter $formatter): void
+    {
+        $listFormatsElement = $this->findOrCreateElement('ListMetadataFormats');
+
+        $formatElement = $this->document->createElement('metadataFormat');
+
+        $listFormatsElement->appendChild($formatElement);
+
+        $prefixElement = $this->document->createElement('metadataPrefix');
+        $prefixElement->nodeValue = $formatter->getMetadataPrefix();
+
+        $formatElement->appendChild($prefixElement);
+
+        $schemaElement = $this->document->createElement('schema');
+        $schemaElement->nodeValue = $formatter->getSchemaUrl();
+
+        $formatElement->appendChild($schemaElement);
+
+        $namespaceElement = $this->document->createElement('metadataNamespace');
+        $namespaceElement->nodeValue = $formatter->getMetadataNamespaceUrl();
+
+        $formatElement->appendChild($namespaceElement);
     }
 
 }

--- a/src/Formatters/OaiDcFormatter.php
+++ b/src/Formatters/OaiDcFormatter.php
@@ -52,6 +52,16 @@ class OaiDcFormatter extends OaiRecordFormatter
         return 'oai_dc';
     }
 
+    public function getMetadataNamespaceUrl(): string
+    {
+        return 'http://www.openarchives.org/OAI/2.0/oai_dc/';
+    }
+
+    public function getSchemaUrl(): string
+    {
+        return 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd';
+    }
+
     public function generateDomElement(
         DOMDocument $document,
         OaiRecord $oaiRecord,
@@ -97,11 +107,11 @@ class OaiDcFormatter extends OaiRecordFormatter
 
         $oaiElement = $document->createElement('oai_dc:dc');
         $oaiElement->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-        $oaiElement->setAttribute('xmlns:oai_dc', 'http://www.openarchives.org/OAI/2.0/oai_dc/');
+        $oaiElement->setAttribute('xmlns:oai_dc', $this->getMetadataNamespaceUrl());
         $oaiElement->setAttribute('xmlns:dc', 'http://purl.org/dc/elements/1.1/');
         $oaiElement->setAttribute(
             'xsi:schemaLocation',
-            'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd'
+            sprintf('%s %s', $this->getMetadataNamespaceUrl(), $this->getSchemaUrl())
         );
 
         $metadataElement->appendChild($oaiElement);

--- a/src/Formatters/OaiRecordFormatter.php
+++ b/src/Formatters/OaiRecordFormatter.php
@@ -12,7 +12,20 @@ abstract class OaiRecordFormatter
 
     use Injectable;
 
+    /**
+     * Value used for the metadataPrefix field
+     */
     abstract public function getMetadataPrefix(): string;
+
+    /**
+     * Value used for the metadataNamespace field
+     */
+    abstract public function getMetadataNamespaceUrl(): string;
+
+    /**
+     * Value used for the schema field
+     */
+    abstract public function getSchemaUrl(): string;
 
     /**
      * The active DOMDocument must be passed to our Formatter. DOMElements must be created through the DOMDocument


### PR DESCRIPTION
## Description

Pretty simple implementation. We expect the `supported_formats` config to be updated with any additional `Formatters`, so we can just use that as our source of truth for which metadata formats we want to add to this verb/endpoint.