### PR TITLE
Move metadata Identifier to a managed field

### DIFF
--- a/src/Formatters/OaiDcFormatter.php
+++ b/src/Formatters/OaiDcFormatter.php
@@ -37,6 +37,7 @@ class OaiDcFormatter extends OaiRecordFormatter
         self::FIELD_CREATOR => OaiRecord::FIELD_CREATORS,
         self::FIELD_DESCRIPTION => OaiRecord::FIELD_DESCRIPTIONS,
         self::FIELD_FORMAT => OaiRecord::FIELD_FORMATS,
+        self::FIELD_IDENTIFIER => OaiRecord::FIELD_IDENTIFIER,
         self::FIELD_LANGUAGE => OaiRecord::FIELD_LANGUAGES,
         self::FIELD_PUBLISHER => OaiRecord::FIELD_PUBLISHERS,
         self::FIELD_RELATION => OaiRecord::FIELD_RELATIONS,
@@ -121,12 +122,6 @@ class OaiDcFormatter extends OaiRecordFormatter
         $dateElement->nodeValue = date('Y-m-d\Th:i:s\Z', strtotime($oaiRecord->LastEdited));
 
         $oaiElement->appendChild($dateElement);
-
-        // Identifier set manually with the identifier we generated above
-        $identifierField = $document->createElement(self::FIELD_IDENTIFIER);
-        $identifierField->nodeValue = $identifier;
-
-        $oaiElement->appendChild($identifierField);
 
         foreach (self::MANAGED_FIELDS as $elementName => $oaiRecordProperty) {
             $this->addMetadataElement($document, $oaiElement, $oaiRecord, $elementName, $oaiRecordProperty);

--- a/src/Models/OaiRecord.php
+++ b/src/Models/OaiRecord.php
@@ -21,6 +21,8 @@ use Terraformers\OpenArchive\Models\Relationships\OaiRecordOaiSet;
  * @property string $Descriptions
  * @property int $Deleted
  * @property string $Formats
+ * @property string $Identifier Note: This should be a URL to the DataObject (Page, File, whatever). Not to be confused
+ * with the header Identifier (which will be automatically generated)
  * @property string $Languages
  * @property string $Publishers
  * @property string $RecordClass
@@ -43,6 +45,7 @@ class OaiRecord extends DataObject
     public const FIELD_DESCRIPTIONS = 'Descriptions';
     public const FIELD_DELETED = 'Deleted';
     public const FIELD_FORMATS = 'Formats';
+    public const FIELD_IDENTIFIER = 'Identifier';
     public const FIELD_LANGUAGES = 'Languages';
     public const FIELD_PUBLISHERS = 'Publishers';
     public const FIELD_RELATIONS = 'Relations';
@@ -58,6 +61,7 @@ class OaiRecord extends DataObject
         self::FIELD_CREATORS,
         self::FIELD_DESCRIPTIONS,
         self::FIELD_FORMATS,
+        self::FIELD_IDENTIFIER,
         self::FIELD_LANGUAGES,
         self::FIELD_PUBLISHERS,
         self::FIELD_RELATIONS,
@@ -77,6 +81,7 @@ class OaiRecord extends DataObject
         self::FIELD_DESCRIPTIONS => 'Text',
         self::FIELD_DELETED => 'Boolean(0)',
         self::FIELD_FORMATS => 'Varchar(255)',
+        self::FIELD_IDENTIFIER => 'Varchar(255)',
         self::FIELD_LANGUAGES => 'Varchar(255)',
         self::FIELD_PUBLISHERS => 'Varchar(255)',
         self::FIELD_RELATIONS => 'Varchar(255)',

--- a/tests/Jobs/OaiRecordUpdateJobTest.php
+++ b/tests/Jobs/OaiRecordUpdateJobTest.php
@@ -76,6 +76,7 @@ class OaiRecordUpdateJobTest extends SapphireTest
         $this->assertEquals('CoverageValue', $oaiRecord->Coverages);
         $this->assertEquals('DescriptionValue', $oaiRecord->Descriptions);
         $this->assertEquals('FormatValue', $oaiRecord->Formats);
+        $this->assertEquals('IdentifierValue', $oaiRecord->Identifier);
         $this->assertEquals('LanguageValue', $oaiRecord->Languages);
         $this->assertEquals('PublisherValue', $oaiRecord->Publishers);
         $this->assertEquals('RelationValue', $oaiRecord->Relations);

--- a/tests/Mocks/SiteTreeExtension.php
+++ b/tests/Mocks/SiteTreeExtension.php
@@ -19,6 +19,7 @@ class SiteTreeExtension extends DataExtension
         OaiRecord::FIELD_COVERAGES => 'getCoverage',
         OaiRecord::FIELD_DESCRIPTIONS => 'MetaDescription',
         OaiRecord::FIELD_FORMATS => 'getFormat',
+        OaiRecord::FIELD_IDENTIFIER => 'getIdentifier',
         OaiRecord::FIELD_LANGUAGES => 'getLanguage',
         OaiRecord::FIELD_PUBLISHERS => 'getPublisher',
         OaiRecord::FIELD_RELATIONS => 'getRelation',
@@ -37,6 +38,11 @@ class SiteTreeExtension extends DataExtension
     public function getFormat(): string
     {
         return 'FormatValue';
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'IdentifierValue';
     }
 
     public function getLanguage(): string


### PR DESCRIPTION
I was informed that the `dc:identifier` (not to be confused with the `identifier` found in the `headers`) was meant to be a link to the resource.

I've added `Identifier` as a `MANAGED_FIELD` so that devs can specify how this `identifier` should be populated (if at all, as it is an optional field for when/if there is no link).