### PR TITLE
Add dev task to update all existing OAI records

### DIFF
--- a/src/Tasks/UpdateOaiRecords.php
+++ b/src/Tasks/UpdateOaiRecords.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Terraformers\OpenArchive\Tasks;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\DataList;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+use Terraformers\OpenArchive\Jobs\OaiRecordUpdateJob;
+use Terraformers\OpenArchive\Models\OaiRecord;
+
+class UpdateOaiRecords extends BuildTask
+{
+
+    private static $segment = 'update-oai-records'; // phpcs:ignore
+
+    protected $title = 'Update OAI Records'; // phpcs:ignore
+
+    protected $description = 'Queue update jobs for all existing OAI Records'; // phpcs:ignore
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        /** @var DataList|OaiRecord[] $oaiRecords */
+        $oaiRecords = OaiRecord::get();
+
+        foreach ($oaiRecords as $oaiRecord) {
+            $job = OaiRecordUpdateJob::create();
+            $job->hydrate($oaiRecord->RecordClass, $oaiRecord->RecordID);
+
+            QueuedJobService::singleton()->queueJob($job);
+        }
+
+        echo 'Jobs queued to update all existing OAI Records';
+    }
+
+}

--- a/src/Tasks/UpdateOaiRecords.php
+++ b/src/Tasks/UpdateOaiRecords.php
@@ -21,7 +21,7 @@ class UpdateOaiRecords extends BuildTask
     /**
      * @param HTTPRequest $request
      */
-    public function run($request) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    public function run($request) // phpcs:ignore
     {
         /** @var DataList|OaiRecord[] $oaiRecords */
         $oaiRecords = OaiRecord::get();


### PR DESCRIPTION
Loops through each OAI Record in our DB and queues a Job to update that record.

Updated the README with an example dev task for how folks might populate the initial set of OAI Records.