### PR TITLE
Add support for ListIdentifiers and GetRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 * [Supported Verbs](#supported-verbs)
   * [Identify](#identify)
   * [List Metadata Formats](#list-metadata-formats)
-  * [List Sets](#list-sets)
-  * [List Identifiers](#list-identifiers)
   * [List Records](#list-records)
+  * [List Identifiers](#list-identifiers)
+  * [List Sets (TBA)](#list-sets-tba)
   * [Get Record](#get-record)
 * [Configuration](#configuration)
   * [OAI Record Managers](#oai-record-managers)
@@ -62,10 +62,6 @@ for this verb.
 
 The response for this endpoint is generated based on the config you specify for `OaiController::$supported_formats`.
 
-### List Identifiers
-
-TBA
-
 ### List Records
 
 This endpoint requires that the request includes a `metadataPrefix` parameter value that matches one of the configs
@@ -81,13 +77,17 @@ Filter support:
   `OaiController::$resumption_token_expiry` config
 * `set`: TBA
 
-### List Sets
+### List Identifiers
+
+Same support as List Records. The only difference is that List Identifiers only provides `headers` for each OAI Record.
+
+### List Sets (TBA)
 
 TBA
 
 ### Get Record
 
-TBA
+Requires harvesters to provide a `metadataPrefix` and `identifier`.
 
 ## OAI Records
 

--- a/src/Documents/GetRecordDocument.php
+++ b/src/Documents/GetRecordDocument.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Terraformers\OpenArchive\Documents;
+
+use Terraformers\OpenArchive\Formatters\OaiRecordFormatter;
+use Terraformers\OpenArchive\Models\OaiRecord;
+
+class GetRecordDocument extends OaiDocument
+{
+
+    private OaiRecordFormatter $formatter;
+
+    public function __construct(OaiRecordFormatter $formatter)
+    {
+        parent::__construct();
+
+        $this->formatter = $formatter;
+        $this->setRequestVerb(OaiDocument::VERB_GET_RECORD);
+        $this->setMetadataPrefix($this->formatter->getMetadataPrefix());
+    }
+
+    public function processOaiRecord(OaiRecord $oaiRecord): void
+    {
+        $rootElement = $this->findOrCreateElement('GetRecord');
+
+        $rootElement->appendChild(
+            $this->formatter->generateDomElement($this->document, $oaiRecord, true)
+        );
+    }
+
+}

--- a/src/Documents/ListIdentifiersDocument.php
+++ b/src/Documents/ListIdentifiersDocument.php
@@ -4,24 +4,24 @@ namespace Terraformers\OpenArchive\Documents;
 
 use Terraformers\OpenArchive\Formatters\OaiRecordFormatter;
 
-class ListRecordsDocument extends RecordsDocument
+class ListIdentifiersDocument extends RecordsDocument
 {
 
     public function __construct(?OaiRecordFormatter $formatter = null)
     {
         parent::__construct($formatter);
 
-        $this->setRequestVerb(OaiDocument::VERB_LIST_RECORDS);
+        $this->setRequestVerb(OaiDocument::VERB_LIST_IDENTIFIERS);
     }
 
     public function shouldIncludeMetadata(): bool
     {
-        return true;
+        return false;
     }
 
     public function getRecordsHolderName(): string
     {
-        return 'ListRecords';
+        return 'ListIdentifiers';
     }
 
 }

--- a/src/Documents/OaiDocument.php
+++ b/src/Documents/OaiDocument.php
@@ -36,6 +36,7 @@ abstract class OaiDocument
     public const ERROR_NO_RECORDS_MATCH = 'noRecordsMatch';
     public const ERROR_NO_SET_HIERARCHY = 'noSetHierarchy';
 
+    public const VERB_GET_RECORD = 'GetRecord';
     public const VERB_IDENTIFY = 'Identify';
     public const VERB_LIST_IDENTIFIERS = 'ListIdentifiers';
     public const VERB_LIST_METADATA_FORMATS = 'ListMetadataFormats';
@@ -76,6 +77,8 @@ abstract class OaiDocument
 
         // Append it to our primary document
         $this->document->appendChild($rootElement);
+        // Set the Response date. Default is simply the time of instantiation
+        $this->setResponseDate();
     }
 
     public function getDocumentBody(): string

--- a/src/Documents/RecordsDocument.php
+++ b/src/Documents/RecordsDocument.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Terraformers\OpenArchive\Documents;
+
+use Exception;
+use SilverStripe\ORM\PaginatedList;
+use Terraformers\OpenArchive\Formatters\OaiRecordFormatter;
+use Terraformers\OpenArchive\Helpers\ResumptionTokenHelper;
+use Terraformers\OpenArchive\Models\OaiRecord;
+
+abstract class RecordsDocument extends OaiDocument
+{
+
+    protected ?OaiRecordFormatter $formatter = null;
+
+    abstract public function shouldIncludeMetadata(): bool;
+
+    abstract public function getRecordsHolderName(): string;
+
+    public function __construct(?OaiRecordFormatter $formatter = null)
+    {
+        parent::__construct();
+
+        if (!$formatter) {
+            return;
+        }
+
+        $this->formatter = $formatter;
+        $this->setMetadataPrefix($this->formatter->getMetadataPrefix());
+    }
+
+    public function setFormatter(OaiRecordFormatter $formatter): void
+    {
+        $this->formatter = $formatter;
+        $this->setMetadataPrefix($this->formatter->getMetadataPrefix());
+    }
+
+    /**
+     * @param PaginatedList|OaiRecord[] $oaiRecords
+     */
+    public function processOaiRecords(PaginatedList $oaiRecords): void
+    {
+        if (!$this->formatter) {
+            throw new Exception('No OAI Record formatter has been set');
+        }
+
+        $recordsHolderElement = $this->findOrCreateElement($this->getRecordsHolderName());
+
+        foreach ($oaiRecords as $oaiRecord) {
+            $recordsHolderElement->appendChild(
+                $this->formatter->generateDomElement($this->document, $oaiRecord, $this->shouldIncludeMetadata())
+            );
+        }
+    }
+
+    public function setResumptionToken(string $resumptionToken): void
+    {
+        $recordsHolderElement = $this->findOrCreateElement($this->getRecordsHolderName());
+        $resumptionTokenElement = $this->findOrCreateElement('resumptionToken', $recordsHolderElement);
+
+        $resumptionTokenElement->nodeValue = $resumptionToken;
+
+        $tokenExpiry = ResumptionTokenHelper::getExpiryFromResumptionToken($resumptionToken);
+
+        if (!$tokenExpiry) {
+            return;
+        }
+
+        $resumptionTokenElement->setAttribute('expirationDate', $tokenExpiry);
+    }
+
+}

--- a/src/Helpers/RecordIdentityHelper.php
+++ b/src/Helpers/RecordIdentityHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Terraformers\OpenArchive\Helpers;
+
+use SilverStripe\Control\Director;
+use Terraformers\OpenArchive\Models\OaiRecord;
+
+class RecordIdentityHelper
+{
+
+    public static function generateOaiIdentifier(OaiRecord $oaiRecord): string
+    {
+        return sprintf('oai:%s:%s', Director::host(), $oaiRecord->ID);
+    }
+
+    public static function getIdFromOaiIdentifier(string $oaiIdentifier): ?int
+    {
+        $parts = explode(':', $oaiIdentifier);
+
+        if (!$parts) {
+            return null;
+        }
+
+        // ID should always be the last element in the array
+        return (int) end($parts);
+    }
+
+}

--- a/tests/Controllers/OaiControllerTest.php
+++ b/tests/Controllers/OaiControllerTest.php
@@ -113,9 +113,10 @@ class OaiControllerTest extends FunctionalTest
     public function verbUrlProvider(): array
     {
         return [
-            ['/api/v1/oai', 'Identify'],
-            ['/api/v1/oai', 'ListMetadataFormats'],
-            ['/api/v1/oai', 'ListRecords', 'oai_dc'],
+            ['/api/v1/oai', OaiDocument::VERB_IDENTIFY],
+            ['/api/v1/oai', OaiDocument::VERB_LIST_METADATA_FORMATS],
+            ['/api/v1/oai', OaiDocument::VERB_LIST_RECORDS, 'oai_dc'],
+            ['/api/v1/oai', OaiDocument::VERB_LIST_IDENTIFIERS, 'oai_dc'],
         ];
     }
 

--- a/tests/Helpers/RecordIdentityHelperTest.php
+++ b/tests/Helpers/RecordIdentityHelperTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Terraformers\OpenArchive\Tests\Helpers;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Dev\SapphireTest;
+use Terraformers\OpenArchive\Helpers\RecordIdentityHelper;
+use Terraformers\OpenArchive\Models\OaiRecord;
+
+class RecordIdentityHelperTest extends SapphireTest
+{
+
+    protected static $fixture_file = 'RecordIdentityHelperTest.yml'; // phpcs:ignore
+
+    public function testGenerateOaiIdentifier(): void
+    {
+        $host = Director::host();
+        $record = $this->objFromFixture(OaiRecord::class, 'record1');
+
+        $this->assertEquals(
+            sprintf('oai:%s:%s', $host, $record->ID),
+            RecordIdentityHelper::generateOaiIdentifier($record)
+        );
+    }
+
+    public function testGetIdFromOaiIdentifier(): void
+    {
+        $host = Director::host();
+        $record = $this->objFromFixture(OaiRecord::class, 'record1');
+        $oaiIdentifier = sprintf('oai:%s:%s', $host, $record->ID);
+
+        $this->assertEquals($record->ID, RecordIdentityHelper::getIdFromOaiIdentifier($oaiIdentifier));
+    }
+
+}

--- a/tests/Helpers/RecordIdentityHelperTest.yml
+++ b/tests/Helpers/RecordIdentityHelperTest.yml
@@ -1,0 +1,3 @@
+Terraformers\OpenArchive\Models\OaiRecord:
+  record1:
+    Titles: Page1


### PR DESCRIPTION
## List Identifiers

This endpoint supports the same filtering and resumption tokens as `ListRecords`. Practically speaking, the only difference between these two end points is that `ListIdentifiers` doesn't include any `metadata` about each record; it only includes `headers`, and as such, the `headers` Element becomes the "root" element (rather than there being a root `record` Element).

Added a new abstract document `RecordsDocument.php` which both `ListRecords` and `ListIdentifiers` extends.

The `OaiController` has been refactored as well so that both `ListRecords` and `ListIdentifiers` are processed by a single method called `getRecordsResponse()`.

## Get Record

A relatively simply endpoint where we fetch one OAI Record based on the OAI identifier provided. The same `OaiRecordFormatter` that we use for `ListRecords`/`ListIdentifiers` is used.

Some minor refactoring with the `RecordIdentifyHelper`. Just making it so that we can generate and OAI identifier, and then on the flip side, we can extract our (local) `ID` from that OAI identifier.