### PR TITLE
Refactor Resumption Tokens for expected behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Filter support:
 
 * `from`: specifies a lower bound for datestamp-based selective harvesting. UTC+0 datetimes must be provided.
 * `until`: specifies an upper bound for datestamp-based selective harvesting. UTC+0 datetimes must be provided.
-* `resumptionToken`: Includes validation of current verb and filters
+* `resumptionToken`: Default to 1 hour expiry time. This can be updated through the
+  `OaiController::$resumption_token_expiry` config
 * `set`: TBA
 
 ### List Sets

--- a/src/Documents/ListRecordsDocument.php
+++ b/src/Documents/ListRecordsDocument.php
@@ -25,7 +25,7 @@ class ListRecordsDocument extends OaiDocument
         $this->setRequestVerb(OaiDocument::VERB_LIST_RECORDS);
     }
 
-    public function setFormatter(OaiRecordFormatter $formatter)
+    public function setFormatter(OaiRecordFormatter $formatter): void
     {
         $this->formatter = $formatter;
         $this->setMetadataPrefix($this->formatter->getMetadataPrefix());

--- a/src/Documents/ListRecordsDocument.php
+++ b/src/Documents/ListRecordsDocument.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\OpenArchive\Documents;
 
+use Exception;
 use SilverStripe\ORM\PaginatedList;
 use Terraformers\OpenArchive\Formatters\OaiRecordFormatter;
 use Terraformers\OpenArchive\Helpers\ResumptionTokenHelper;
@@ -10,14 +11,23 @@ use Terraformers\OpenArchive\Models\OaiRecord;
 class ListRecordsDocument extends OaiDocument
 {
 
-    private OaiRecordFormatter $formatter;
+    private ?OaiRecordFormatter $formatter = null;
 
-    public function __construct(OaiRecordFormatter $formatter)
+    public function __construct(?OaiRecordFormatter $formatter = null)
     {
         parent::__construct();
 
-        $this->formatter = $formatter;
+        if ($formatter) {
+            $this->setMetadataPrefix($this->formatter->getMetadataPrefix());
+            $this->formatter = $formatter;
+        }
+
         $this->setRequestVerb(OaiDocument::VERB_LIST_RECORDS);
+    }
+
+    public function setFormatter(OaiRecordFormatter $formatter)
+    {
+        $this->formatter = $formatter;
         $this->setMetadataPrefix($this->formatter->getMetadataPrefix());
     }
 
@@ -26,6 +36,10 @@ class ListRecordsDocument extends OaiDocument
      */
     public function processOaiRecords(PaginatedList $oaiRecords): void
     {
+        if (!$this->formatter) {
+            throw new Exception('No OAI Record formatter has been set');
+        }
+
         $listRecordsElement = $this->findOrCreateElement('ListRecords');
 
         foreach ($oaiRecords as $oaiRecord) {

--- a/src/Helpers/DateTimeHelper.php
+++ b/src/Helpers/DateTimeHelper.php
@@ -9,8 +9,12 @@ use Exception;
 class DateTimeHelper
 {
 
-    public static function getLocalStringFromUtc(string $utcDateString): string
+    public static function getLocalStringFromUtc(?string $utcDateString = null): ?string
     {
+        if (!$utcDateString) {
+            return null;
+        }
+
         if (!static::isSupportedUtcFormat($utcDateString)) {
             throw new Exception('Invalid UTC date format provided');
         }
@@ -19,8 +23,12 @@ class DateTimeHelper
         return date('Y-m-d H:i:s', strtotime($utcDateString));
     }
 
-    public static function getUtcStringFromLocal(string $localDateString): string
+    public static function getUtcStringFromLocal(?string $localDateString = null): ?string
     {
+        if (!$localDateString) {
+            return null;
+        }
+
         $dateTime = new DateTime($localDateString);
         $dateTime->setTimezone(new DateTimeZone('UTC'));
 

--- a/tests/Helpers/DateTimeHelperTest.php
+++ b/tests/Helpers/DateTimeHelperTest.php
@@ -8,6 +8,12 @@ use Terraformers\OpenArchive\Helpers\DateTimeHelper;
 class DateTimeHelperTest extends SapphireTest
 {
 
+    public function testNullStrings(): void
+    {
+        $this->assertNull(DateTimeHelper::getLocalStringFromUtc());
+        $this->assertNull(DateTimeHelper::getUtcStringFromLocal());
+    }
+
     public function testGetUtcStringFromLocal(): void
     {
         // We'll use Auckland time for our tests


### PR DESCRIPTION
Ok, so I got Resumption Tokens all wrong.

I thought they were meant to be a form of validation to make sure that Harvesters didn’t accidentally use the pagination number with changing filters, but that’s not the case at all.

Resumption Tokens are simply meant to collate any/all request params (except verb) so that Harversters don’t have to persist their filters between requests.

EG:

The first request might be `?verb=ListRecords&metadataPrefix=oai_dc&from=[somedate]`

We would then add `metadataPrefix`, `from`, and the next `page` to our resumption token. The next request would simply be `?verb=ListRecords&resumptionToken=[hash]`. Our `[hash]` would include all of the filters, pagination, and metadata prefix.