### PR TITLE
Adjust header elements of deleted items to use an attribute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@v0.1
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.7",
-        "symbiote/silverstripe-queuedjobs": "^4"
+        "symbiote/silverstripe-queuedjobs": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.7",
-        "symbiote/silverstripe-queuedjobs": "^4.1"
+        "silverstripe/framework": "^4.11",
+        "symbiote/silverstripe-queuedjobs": "^4.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,11 @@
         <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
     </rule>
 
+    <!-- Do not require Test classes to define Type Hints - we're forced to exclude them due to how we extend -->
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint">
+        <exclude-pattern>app/tests/*</exclude-pattern>
+    </rule>
+
     <!-- All "use" statements must be used in the code. -->
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
         <!-- Comments after code are fine. It's how we disable rules when we need to -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,11 @@
     <file>src</file>
     <file>tests</file>
 
+    <!-- Show progress and output sniff names on violation, and add colours -->
+    <arg value="p" />
+    <arg name="colors" />
+    <arg value="s" />
+
     <rule ref="PSR2">
         <!-- Allow non camel cased method names - some base SS method names are PascalCase or snake_case -->
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>

--- a/src/Formatters/OaiDcFormatter.php
+++ b/src/Formatters/OaiDcFormatter.php
@@ -14,7 +14,6 @@ class OaiDcFormatter extends OaiRecordFormatter
     private const FIELD_HEADER_DATESTAMP = 'datestamp';
     private const FIELD_HEADER_IDENTIFIER = 'identifier';
     private const FIELD_HEADER_SET_SPEC = 'setSpec';
-    private const FIELD_HEADER_STATUS = 'status';
 
     private const FIELD_CONTRIBUTOR = 'dc:contributor';
     private const FIELD_COVERAGE = 'dc:coverage';
@@ -99,10 +98,7 @@ class OaiDcFormatter extends OaiRecordFormatter
         }
 
         if ($oaiRecord->Deleted) {
-            $statusElement = $document->createElement(self::FIELD_HEADER_STATUS);
-            $statusElement->nodeValue = 'deleted';
-
-            $headerElement->appendChild($statusElement);
+            $headerElement->setAttribute('status', 'deleted');
         }
 
         if (!$includeMetadata) {

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Terraformers\OpenArchive\Tests\Documents;
+
+use SilverStripe\Assets\File;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use Terraformers\OpenArchive\Documents\GetRecordDocument;
+use Terraformers\OpenArchive\Extensions\VersionedOaiRecordManager;
+use Terraformers\OpenArchive\Formatters\OaiDcFormatter;
+use Terraformers\OpenArchive\Jobs\OaiRecordUpdateJob;
+use Terraformers\OpenArchive\Tests\Mocks\FileExtension;
+use Terraformers\OpenArchive\Tests\Mocks\SiteTreeExtension;
+
+class GetRecordDocumentTest extends SapphireTest
+{
+
+    protected static $fixture_file = 'GetRecordDocumentTest.yml'; // phpcs:ignore
+
+    protected static $required_extensions = [
+        SiteTree::class => [
+            VersionedOaiRecordManager::class,
+            SiteTreeExtension::class,
+        ],
+    ];
+
+    public function testProcessOaiRecord(): void
+    {
+        // Mock OaiDcFormatter and mock GetRecordDocument
+        $formatter = new OaiDcFormatter();
+        $xmlDocument = GetRecordDocument::create($formatter);
+
+        // Get a mock OaiRecord and Page record
+        $page = $this->objFromFixture(SiteTree::class, 'page');
+        $oaiRecord = $page->OaiRecords()->first();
+
+        // Get the contents of the document
+        $originalDocumentBody = $xmlDocument->getDocumentBody();
+
+        // Confirm that this record has the contents of the mock file
+        $this->assertNotNull($originalDocumentBody);
+        $this->assertStringNotContainsString('<header>', $originalDocumentBody);
+        $this->assertStringContainsString('OAI-PMH', $originalDocumentBody);
+        $this->assertStringContainsString('<responseDate id="responseDate">', $originalDocumentBody);
+        $this->assertStringContainsString(
+            '<request id="request" verb="GetRecord" metadataPrefix="oai_dc"/>',
+            $originalDocumentBody
+        );
+        $this->assertEquals('0', $oaiRecord->Deleted);
+
+        // Run the test function with our mock Oai record
+        $xmlDocument->processOaiRecord($oaiRecord);
+
+        // Extract the document body after the main test has been executed
+        $extractedDocumentBody = $xmlDocument->getDocumentBody();
+
+        // Assert that we have the correct header attributes and that we do not see a 'status' element
+        $this->assertStringContainsString('<header>', $extractedDocumentBody);
+        $this->assertStringContainsString('<identifier>', $extractedDocumentBody);
+        $this->assertStringContainsString('<datestamp>', $extractedDocumentBody);
+        $this->assertStringNotContainsString("<status>deleted</status>", $extractedDocumentBody);
+
+        // Simulate the deletion of a document
+        $page->doArchive();
+        $job = OaiRecordUpdateJob::create();
+        $job->hydrate($page->ClassName, $page->ID);
+        $job->process();
+
+        // Get the updated OaiRecord once the page has been archived
+        $oaiRecordUpdated = $page->OaiRecords()->first();
+
+        // Check that the updated OaiRecord has been deleted
+        $this->assertEquals('1', $oaiRecordUpdated->Deleted);
+
+        // Process the updated OaiRecord and get the processed DocumentBody
+        $xmlDocument->processOaiRecord($oaiRecordUpdated);
+        $processedDocumentBody = $xmlDocument->getDocumentBody();
+
+        // Check that our 'header' element now contains a 'status' attribute
+        $this->assertStringContainsString('<header>', $processedDocumentBody);
+        $this->assertStringContainsString('<identifier>', $processedDocumentBody);
+        $this->assertStringContainsString('<datestamp>', $processedDocumentBody);
+        $this->assertStringContainsString('status="deleted"', $processedDocumentBody);
+        $this->assertStringNotContainsString("<status>deleted</status>", $processedDocumentBody);
+    }
+
+}

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -16,7 +16,7 @@ class GetRecordDocumentTest extends SapphireTest
     protected static $fixture_file = 'GetRecordDocumentTest.yml'; // phpcs:ignore
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     * @var array
      */
     protected static $required_extensions = [
         SiteTree::class => [

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -58,7 +58,7 @@ class GetRecordDocumentTest extends SapphireTest
         $this->assertStringContainsString('<header>', $extractedDocumentBody);
         $this->assertStringContainsString('<identifier>', $extractedDocumentBody);
         $this->assertStringContainsString('<datestamp>', $extractedDocumentBody);
-        $this->assertStringNotContainsString('<header status="deleted">', $processedDocumentBody);
+        $this->assertStringNotContainsString('<header status="deleted">', $extractedDocumentBody);
 
         // Simulate the deletion of a document
         $page->doArchive();

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -58,7 +58,7 @@ class GetRecordDocumentTest extends SapphireTest
         $this->assertStringContainsString('<header>', $extractedDocumentBody);
         $this->assertStringContainsString('<identifier>', $extractedDocumentBody);
         $this->assertStringContainsString('<datestamp>', $extractedDocumentBody);
-        $this->assertStringNotContainsString("<status>deleted</status>", $extractedDocumentBody);
+        $this->assertStringNotContainsString('<header status="deleted">', $processedDocumentBody);
 
         // Simulate the deletion of a document
         $page->doArchive();
@@ -77,11 +77,11 @@ class GetRecordDocumentTest extends SapphireTest
         $processedDocumentBody = $xmlDocument->getDocumentBody();
 
         // Check that our 'header' element now contains a 'status' attribute
+        $this->assertStringContainsString('<header status="deleted">', $processedDocumentBody);
+        // There should also be a non-deleted header element present.
         $this->assertStringContainsString('<header>', $processedDocumentBody);
         $this->assertStringContainsString('<identifier>', $processedDocumentBody);
         $this->assertStringContainsString('<datestamp>', $processedDocumentBody);
-        $this->assertStringContainsString('status="deleted"', $processedDocumentBody);
-        $this->assertStringNotContainsString("<status>deleted</status>", $processedDocumentBody);
     }
 
 }

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -15,7 +15,10 @@ class GetRecordDocumentTest extends SapphireTest
 
     protected static $fixture_file = 'GetRecordDocumentTest.yml'; // phpcs:ignore
 
-    protected static array $required_extensions = [
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
         SiteTree::class => [
             VersionedOaiRecordManager::class,
             SiteTreeExtension::class,

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -16,7 +16,7 @@ class GetRecordDocumentTest extends SapphireTest
     protected static $fixture_file = 'GetRecordDocumentTest.yml'; // phpcs:ignore
 
     /**
-     * @var array
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      */
     protected static $required_extensions = [
         SiteTree::class => [

--- a/tests/Documents/GetRecordDocumentTest.php
+++ b/tests/Documents/GetRecordDocumentTest.php
@@ -2,14 +2,12 @@
 
 namespace Terraformers\OpenArchive\Tests\Documents;
 
-use SilverStripe\Assets\File;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 use Terraformers\OpenArchive\Documents\GetRecordDocument;
 use Terraformers\OpenArchive\Extensions\VersionedOaiRecordManager;
 use Terraformers\OpenArchive\Formatters\OaiDcFormatter;
 use Terraformers\OpenArchive\Jobs\OaiRecordUpdateJob;
-use Terraformers\OpenArchive\Tests\Mocks\FileExtension;
 use Terraformers\OpenArchive\Tests\Mocks\SiteTreeExtension;
 
 class GetRecordDocumentTest extends SapphireTest
@@ -17,7 +15,7 @@ class GetRecordDocumentTest extends SapphireTest
 
     protected static $fixture_file = 'GetRecordDocumentTest.yml'; // phpcs:ignore
 
-    protected static $required_extensions = [
+    protected static array $required_extensions = [
         SiteTree::class => [
             VersionedOaiRecordManager::class,
             SiteTreeExtension::class,

--- a/tests/Documents/GetRecordDocumentTest.yml
+++ b/tests/Documents/GetRecordDocumentTest.yml
@@ -1,0 +1,8 @@
+SilverStripe\CMS\Model\SiteTree:
+  page:
+    Title: Page Title
+
+Terraformers\OpenArchive\Models\OaiRecord:
+  record:
+    Titles: Record Titles
+    Record: =>SilverStripe\CMS\Model\SiteTree.page

--- a/tests/Formatters/OaiDcFormatterTest.php
+++ b/tests/Formatters/OaiDcFormatterTest.php
@@ -15,7 +15,7 @@ class OaiDcFormatterTest extends SapphireTest
     protected static $fixture_file = 'OaiDcFormatterTest.yml'; // phpcs:ignore
 
     /**
-     * @var array
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      */
     protected static $required_extensions = [
         SiteTree::class => [

--- a/tests/Formatters/OaiDcFormatterTest.php
+++ b/tests/Formatters/OaiDcFormatterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Terraformers\OpenArchive\Tests\Formatters;
+
+use DOMDocument;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use Terraformers\OpenArchive\Extensions\VersionedOaiRecordManager;
+use Terraformers\OpenArchive\Formatters\OaiDcFormatter;
+use Terraformers\OpenArchive\Tests\Mocks\SiteTreeExtension;
+
+class OaiDcFormatterTest extends SapphireTest
+{
+
+    protected static $fixture_file = 'OaiDcFormatterTest.yml'; // phpcs:ignore
+
+    protected static $required_extensions = [
+        SiteTree::class => [
+            VersionedOaiRecordManager::class,
+            SiteTreeExtension::class,
+        ],
+    ];
+
+    public function testGenerateDomElement(): void
+    {
+        // Mock OaiDcFormatter and mock DOMDocument
+        $formatter = new OaiDcFormatter();
+        $document = new DOMDocument();
+
+        // Get a mock OaiRecord and Page record
+        $page = $this->objFromFixture(SiteTree::class, 'page');
+        $oaiRecord = $page->OaiRecords()->first();
+
+        // Test the function with our mock fixtures
+        $result = $formatter->generateDomElement($document, $oaiRecord, true);
+
+        // Check our DOMElement exists, that we have the 'oai' tag, and check the page title
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('oai', $result->nodeValue);
+        $this->assertStringContainsString('Record Titles', $result->nodeValue);
+    }
+
+}

--- a/tests/Formatters/OaiDcFormatterTest.php
+++ b/tests/Formatters/OaiDcFormatterTest.php
@@ -14,7 +14,7 @@ class OaiDcFormatterTest extends SapphireTest
 
     protected static $fixture_file = 'OaiDcFormatterTest.yml'; // phpcs:ignore
 
-    protected static $required_extensions = [
+    protected static array $required_extensions = [
         SiteTree::class => [
             VersionedOaiRecordManager::class,
             SiteTreeExtension::class,

--- a/tests/Formatters/OaiDcFormatterTest.php
+++ b/tests/Formatters/OaiDcFormatterTest.php
@@ -15,7 +15,7 @@ class OaiDcFormatterTest extends SapphireTest
     protected static $fixture_file = 'OaiDcFormatterTest.yml'; // phpcs:ignore
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     * @var array
      */
     protected static $required_extensions = [
         SiteTree::class => [

--- a/tests/Formatters/OaiDcFormatterTest.php
+++ b/tests/Formatters/OaiDcFormatterTest.php
@@ -14,7 +14,10 @@ class OaiDcFormatterTest extends SapphireTest
 
     protected static $fixture_file = 'OaiDcFormatterTest.yml'; // phpcs:ignore
 
-    protected static array $required_extensions = [
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
         SiteTree::class => [
             VersionedOaiRecordManager::class,
             SiteTreeExtension::class,

--- a/tests/Formatters/OaiDcFormatterTest.yml
+++ b/tests/Formatters/OaiDcFormatterTest.yml
@@ -1,0 +1,8 @@
+SilverStripe\CMS\Model\SiteTree:
+  page:
+    Title: Page Title
+
+Terraformers\OpenArchive\Models\OaiRecord:
+  record:
+    Titles: Record Titles
+    Record: =>SilverStripe\CMS\Model\SiteTree.page


### PR DESCRIPTION
This change updates the `<header>` tag for deleted items, removing the element `<status>deleted</status>` and replacing it with attribute on the header element, `<header status="deleted">`.

Two unit tests have been added (content largely courtesy of @pjayme): GetRecordDocumentTest recreates the workflow of deleting an object, checking its header before and after, however because `generateDomElement()` (the function controlling the deletion markers) is a protected function, this test actually uses `processOaiRecord()`. The other test, OaiDcFormatterTest checks `generateDomElement()` directly.
