### PR TITLE
Make OAI record sorting consistent across paginated pages

### DIFF
--- a/src/Controllers/OaiController.php
+++ b/src/Controllers/OaiController.php
@@ -421,7 +421,7 @@ class OaiController extends Controller
         }
 
         if (!$filters) {
-            return PaginatedList::create(OaiRecord::get());
+            return PaginatedList::create(OaiRecord::get()->sort('LastEdited ASC'));
         }
 
         $list = OaiRecord::get()

--- a/tests/Controllers/OaiControllerTest.yml
+++ b/tests/Controllers/OaiControllerTest.yml
@@ -1,0 +1,14 @@
+Terraformers\OpenArchive\Models\OaiSet:
+  set1:
+    Title: Set1
+
+Terraformers\OpenArchive\Models\OaiRecord:
+  recordA:
+    Titles: Random Record A
+    OaiSets: =>Terraformers\OpenArchive\Models\OaiSet.set1
+  recordB:
+    Titles: Random Record B
+    OaiSets: =>Terraformers\OpenArchive\Models\OaiSet.set1
+  recordC:
+    Titles: Random Record C
+    OaiSets: =>Terraformers\OpenArchive\Models\OaiSet.set1


### PR DESCRIPTION
This change updates the default filtering on function `OaiRecords.php fetchOaiRecords()` to consistently return results in order of LastEdited ascending, if no filters are in place. 

At the moment there is no sorting of unfiltered results, and as per [this issue](https://github.com/silverstripe-terraformers/open-archive-initiative-repository/issues/17), which creates problems as the first page of the PaginatedList is returned in a random order, but the second and later pages are sorted, meaning some items are never visible; see also [this LincolnLTL ticket](https://silverstripe.atlassian.net/browse/LU-1354) where the client first described the issue.

Kudos again to Tobie for helping me figure out some knotty bits of the phpunit test.